### PR TITLE
Add Connection.execute() method.

### DIFF
--- a/alchimia/engine.py
+++ b/alchimia/engine.py
@@ -33,7 +33,7 @@ class TwistedEngine(object):
 
     def connect(self):
         d = self._defer_to_thread(self._engine.connect)
-        d.addCallback(TwistedConnection)
+        d.addCallback(TwistedConnection, self)
         return d
 
     def execute(self, *args, **kwargs):
@@ -43,9 +43,16 @@ class TwistedEngine(object):
 
 
 class TwistedConnection(object):
-    def __init__(self, connection):
+    def __init__(self, connection, engine):
         super(TwistedConnection, self).__init__()
         self._connection = connection
+        self._engine = engine
+
+    def execute(self, *args, **kwargs):
+        d = self._engine._defer_to_thread(
+            self._connection.execute, *args, **kwargs)
+        d.addCallback(TwistedResultProxy, self._engine)
+        return d
 
 
 class TwistedResultProxy(object):

--- a/docs/api-reference.rst
+++ b/docs/api-reference.rst
@@ -26,6 +26,11 @@ you to :doc:`file bugs </contributing>` in those cases.
     Mostly like :class:`sqlalchemy.engine.Connection` except some of the
     methods return ``Deferreds``.
 
+    .. method:: execute(*args, **kwargs)
+
+        Like the SQLAlchemy method of the same name, except returns a
+        ``Deferred`` which fires with a :class:`TwistedResultProxy`.
+
 
 .. class:: TwistedResultProxy
 

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -34,9 +34,18 @@ class TestConnect(unittest.TestCase):
 
 
 class TestConnection(unittest.TestCase):
-    def test_execute(self):
+    def test_engine_execute(self):
         engine = create_engine()
         d = engine.execute("SELECT 42")
+        result = self.successResultOf(d)
+        d = result.scalar()
+        assert self.successResultOf(d) == 42
+
+    def test_connection_execute(self):
+        engine = create_engine()
+        d = engine.connect()
+        conn = self.successResultOf(d)
+        d = conn.execute("SELECT 42")
         result = self.successResultOf(d)
         d = result.scalar()
         assert self.successResultOf(d) == 42


### PR DESCRIPTION
This is the first step in making the `Connection` class useful.

The tests could probably use some rearranging, but I'm not sure how you want to do that.
