### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python: 2.7
 env:
     - TOX_ENV=py26
     - TOX_ENV=py27
+    - TOX_ENV=py33
+    - TOX_ENV=py34
     - TOX_ENV=pypy
     - TOX_ENV=docs
     - TOX_ENV=pep8

--- a/alchimia/__init__.py
+++ b/alchimia/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division
+
 from alchimia.strategy import TwistedEngineStrategy, TWISTED_STRATEGY
 
 

--- a/alchimia/engine.py
+++ b/alchimia/engine.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division
+
 from sqlalchemy.engine.base import Engine
 
 from twisted.internet.threads import deferToThreadPool

--- a/alchimia/strategy.py
+++ b/alchimia/strategy.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division
+
 from sqlalchemy.engine.strategies import DefaultEngineStrategy
 
 from alchimia.engine import TwistedEngine

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division
+
 import sqlalchemy
 from sqlalchemy.engine import RowProxy
 from sqlalchemy.exc import StatementError

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pypy,docs,pep8
+envlist = py26,py27,py33,py34,pypy,docs,pep8
 
 [testenv]
 deps =


### PR DESCRIPTION
Twisted thread support is now available in a released Twisted, so -- alchimia will work on py3.