### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Documentation
 
 The documentation is all on `Read the Docs`_.
 
-.. _`Read the Docs`: https://alchimia.readthedocs.org/
+.. _`Read the Docs`: https://alchimia.readthedocs.io/
 
 Limitations
 -----------
@@ -73,4 +73,4 @@ API.
   Luckily, many of these methods have alternate spelling. `The docs`_ call these
   out in more detail.
 
-.. _`The docs`: https://alchimia.readthedocs.org/en/latest/limitations/
+.. _`The docs`: https://alchimia.readthedocs.io/en/latest/limitations/


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.