### PR TITLE
Remove 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: python
 python: 2.7
 env:
-    - TOX_ENV=py26
     - TOX_ENV=py27
     - TOX_ENV=py33
     - TOX_ENV=py34

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,pypy,docs,pep8
+envlist = py27,py33,py34,pypy,docs,pep8
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 2.6 has been end-of-life since 2013: https://alexgaynor.net/2015/mar/30/red-hat-open-source-community/