### PR TITLE
use twisted._threads module to address concurrency issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: python
 python: 2.7
 env:
-    - TOX_ENV=py26
     - TOX_ENV=py27
     - TOX_ENV=py33
     - TOX_ENV=py34

--- a/alchimia/engine.py
+++ b/alchimia/engine.py
@@ -12,7 +12,7 @@ from threading import Thread
 
 try:
     from Queue import Queue
-except:
+except ImportError:
     from queue import Queue
 
 

--- a/alchimia/engine.py
+++ b/alchimia/engine.py
@@ -15,6 +15,7 @@ try:
 except:
     from queue import Queue
 
+
 def _threaded_worker():
     def _start_thread(target):
         thread = Thread(target=target)
@@ -25,6 +26,7 @@ def _threaded_worker():
 
 def _defer_to_worker(deliver, worker, work, *args, **kwargs):
     deferred = Deferred()
+
     @worker.do
     def container():
         try:
@@ -86,7 +88,6 @@ class TwistedEngine(object):
         return (_defer_to_worker(self._reactor.callFromThread, worker,
                                  self._engine.connect)
                 .addCallback(TwistedConnection, self, worker))
-
 
 
 class TwistedConnection(object):

--- a/alchimia/engine.py
+++ b/alchimia/engine.py
@@ -114,25 +114,25 @@ class TwistedConnection(object):
 
     def begin(self, *args, **kwargs):
         return (self._defer_to_cxn(self._connection.begin, *args, **kwargs)
-                .addCallback(TwistedTransaction, self))
+                .addCallback(lambda txn: TwistedTransaction(txn, self)))
 
     def in_transaction(self):
         return self._connection.in_transaction()
 
 
 class TwistedTransaction(object):
-    def __init__(self, transaction, engine):
+    def __init__(self, transaction, cxn):
         self._transaction = transaction
-        self._engine = engine
+        self._cxn = cxn
 
     def commit(self):
-        return self._defer_to_cxn(self._transaction.commit)
+        return self._cxn._defer_to_cxn(self._transaction.commit)
 
     def rollback(self):
-        return self._defer_to_cxn(self._transaction.rollback)
+        return self._cxn._defer_to_cxn(self._transaction.rollback)
 
     def close(self):
-        return self._defer_to_cxn(self._transaction.close)
+        return self._cxn._defer_to_cxn(self._transaction.close)
 
 
 class TwistedResultProxy(object):

--- a/alchimia/engine.py
+++ b/alchimia/engine.py
@@ -83,7 +83,7 @@ class TwistedEngine(object):
 
     def connect(self):
         worker = _new_worker()
-        return (_defer_to_worker(self._engine._reactor.callFromThread, worker,
+        return (_defer_to_worker(self._reactor.callFromThread, worker,
                                  self._engine.connect)
                 .addCallback(TwistedConnection, self, worker))
 

--- a/alchimia/engine.py
+++ b/alchimia/engine.py
@@ -83,7 +83,7 @@ class TwistedEngine(object):
 
     def connect(self):
         worker = _new_worker()
-        return (_defer_to_worker(self._reactor.callFromThread, worker,
+        return (_defer_to_worker(self._engine._reactor.callFromThread, worker,
                                  self._engine.connect)
                 .addCallback(TwistedConnection, self, worker))
 
@@ -96,7 +96,7 @@ class TwistedConnection(object):
         self._cxn_worker = worker
 
     def _defer_to_cxn(self, f, *a, **k):
-        return _defer_to_worker(self._reactor.callFromThread,
+        return _defer_to_worker(self._engine._reactor.callFromThread,
                                 self._cxn_worker, f, *a, **k)
 
     def execute(self, *args, **kwargs):

--- a/alchimia/engine.py
+++ b/alchimia/engine.py
@@ -7,7 +7,12 @@ from twisted._threads import ThreadWorker
 from twisted.internet.defer import Deferred
 from twisted.python.failure import Failure
 
-from threading import Thread, Queue
+from threading import Thread
+
+try:
+    from Queue import Queue
+except:
+    from queue import Queue
 
 def _start_thread(target):
     thread = Thread(target=target)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -12,12 +12,13 @@ from alchimia.engine import (
     TwistedEngine, TwistedConnection, TwistedTransaction,
 )
 
-from .doubles import FakeThreadedReactor, FakeThreadPool, UnthreadedReactor
+from .doubles import FakeThreadedReactor, ImmediateWorker
 
 
 def create_engine():
     return sqlalchemy.create_engine(
-        "sqlite://", strategy=TWISTED_STRATEGY, reactor=FakeThreadedReactor()
+        "sqlite://", strategy=TWISTED_STRATEGY, reactor=FakeThreadedReactor(),
+        create_worker=ImmediateWorker,
     )
 
 
@@ -29,18 +30,6 @@ class TestEngineCreation(unittest.TestCase):
             reactor=FakeThreadedReactor()
         )
         assert isinstance(engine, TwistedEngine)
-
-    def test_explicit_pool(self):
-        engine = sqlalchemy.create_engine(
-            "sqlite://",
-            strategy=TWISTED_STRATEGY,
-            reactor=UnthreadedReactor(),
-            thread_pool=FakeThreadPool(),
-        )
-        assert isinstance(engine, TwistedEngine)
-        d = engine.connect()
-        connection = self.successResultOf(d)
-        assert isinstance(connection, TwistedConnection)
 
 
 class TestEngine(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,pypy,docs,pep8
+envlist = py27,py33,py34,pypy,docs,pep8
 
 [testenv]
 deps =


### PR DESCRIPTION
Fixes #25 

This pins each `TwistedConnection` object to a dedicated daemon thread.