### PR TITLE
Adds testenvs to run test against postgres on Travis-CI via psycopg2cffi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 
 language: python
-python: 2.7
+python: 3.5
 
 services:
     - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,22 @@ sudo: false
 
 language: python
 python: 2.7
+
+services:
+    - postgresql
+
+before_script:
+    - psql -c 'create database travis_ci_test;' -U postgres
+
 env:
     - TOX_ENV=py27
+    - TOX_ENV=py27-psycopg2cffi
     - TOX_ENV=py33
     - TOX_ENV=py34
+    - TOX_ENV=py35
+    - TOX_ENV=py35-psycopg2cffi
     - TOX_ENV=pypy
+    - TOX_ENV=pypy-psycopg2cffi
     - TOX_ENV=docs
     - TOX_ENV=pep8
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,5 +13,5 @@ universal = 1
 all_files = 1
 source-dir = docs
 
-[pytest]
+[tool:pytest]
 norecursedirs = *.egg .tox

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,2 @@
 pytest
+psycopg2cffi

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import, division
 
 import os
 from binascii import hexlify
+from random import Random
+
 
 import sqlalchemy
 from sqlalchemy import (Table, Column, String, Integer)
@@ -116,9 +118,9 @@ class TestEngine(unittest.TestCase):
             pool_size = pool_size()
         if isinstance(engine._engine.pool, sqlalchemy.pool.QueuePool):
             pool_size += engine._engine.pool._max_overflow
+        arbitrary = Random()
         for _ in range(pool_size + 1):
-            from random import Random
-            entry = Random().choice(list(range(3)))
+            entry = arbitrary.choice(list(range(3)))
             d = engine.execute(table.select().where(
                 table.c.id == data[entry]['id']))
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -4,7 +4,6 @@ import os
 from binascii import hexlify
 
 import sqlalchemy
-from sqlalchemy import (Table, Column, String, Integer)
 from sqlalchemy.engine import RowProxy
 from sqlalchemy.exc import StatementError
 from sqlalchemy.schema import CreateTable
@@ -96,35 +95,6 @@ class TestEngine(unittest.TestCase):
         self.successResultOf(d)
         d = engine.has_table('mytable')
         assert self.successResultOf(d) is True
-
-    def test_pooled_connection_reuse(self):
-        table = Table('my_pool_table', sqlalchemy.MetaData(),
-                      Column('id', Integer, primary_key=True),
-                      Column('name', String, nullable=False))
-        data = [{'id': 0,
-                 'name': 'a'},
-                {'id': 1,
-                 'name': 'b'},
-                {'id': 2,
-                 'name': 'c'}]
-        # max_overflow kwarg broken, but defaults to 10
-        engine = create_engine()
-        engine.execute(CreateTable(table))
-        engine.execute(table.insert(), data)
-        pool_size = engine._engine.pool.size
-        if callable(pool_size):
-            pool_size = pool_size()
-        if isinstance(engine._engine.pool, sqlalchemy.pool.QueuePool):
-            pool_size += engine._engine.pool._max_overflow
-        for i in range(pool_size + 1):
-            entry = data[i % len(data)]
-            d = engine.execute(table.select().where(
-                table.c.id == entry['id']))
-
-            result = self.successResultOf(d)
-            result = result.fetchone()
-            result = self.successResultOf(result)
-            assert result['name'] == entry['name']
 
 
 class TestConnection(unittest.TestCase):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import, division
 
 import os
 from binascii import hexlify
-from random import Random
-
 
 import sqlalchemy
 from sqlalchemy import (Table, Column, String, Integer)
@@ -118,16 +116,15 @@ class TestEngine(unittest.TestCase):
             pool_size = pool_size()
         if isinstance(engine._engine.pool, sqlalchemy.pool.QueuePool):
             pool_size += engine._engine.pool._max_overflow
-        arbitrary = Random()
-        for _ in range(pool_size + 1):
-            entry = arbitrary.choice(list(range(3)))
+        for i in range(pool_size + 1):
+            entry = data[i % len(data)]
             d = engine.execute(table.select().where(
-                table.c.id == data[entry]['id']))
+                table.c.id == entry['id']))
 
             result = self.successResultOf(d)
             result = result.fetchone()
             result = self.successResultOf(result)
-            assert result['name'] == data[entry]['name']
+            assert result['name'] == entry['name']
 
 
 class TestConnection(unittest.TestCase):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -29,7 +29,7 @@ def create_engine(**kwargs):
         reactor=FakeThreadedReactor(), create_worker=ImmediateWorker,
         **kwargs)
     if TEST_DB_URL.startswith("postgresql"):
-        tmpdb_name = "testdb"+hexlify(os.urandom(16))
+        tmpdb_name = "testdb"+hexlify(os.urandom(16)).decode()
         tmpdb_url = '/'.join(
             TEST_DB_URL.split('/')[:-1] + [tmpdb_name])
         conn = engine.connect().result
@@ -97,7 +97,7 @@ class TestEngine(unittest.TestCase):
         d = engine.has_table('mytable')
         assert self.successResultOf(d) is True
 
-    def test_more_queries_than_queuepool_slots(self):
+    def test_pooled_connection_reuse(self):
         table = Table('my_pool_table', sqlalchemy.MetaData(),
                       Column('id', Integer, primary_key=True),
                       Column('name', String, nullable=False))

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,6 @@ commands = py.test
 
 [testenv:pypy-psycopg2cffi]
 setenv = TEST_DB_URL=postgresql+psycopg2cffi://postgres@/travis_ci_test
-# Local Testing: `docker run -it --rm -p5432:5432 -ePOSTGRES_DB=travis_ci_test postgres`
-# Then uncomment the line below
-#setenv = TEST_DB_URL=postgresql+psycopg2cffi://postgres@127.0.01/travis_ci_test
 
 [testenv:py27-psycopg2cffi]
 setenv = TEST_DB_URL=postgresql+psycopg2cffi://postgres@/travis_ci_test

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,pypy,docs,pep8
+envlist = py27,py33,py34,py35,pypy,docs,pep8
 
 [testenv]
 deps =
@@ -16,7 +16,7 @@ setenv = TEST_DB_URL=postgresql+psycopg2cffi://postgres@/travis_ci_test
 [testenv:py27-psycopg2cffi]
 setenv = TEST_DB_URL=postgresql+psycopg2cffi://postgres@/travis_ci_test
 
-[testenv:py34-psycopg2cffi]
+[testenv:py35-psycopg2cffi]
 setenv = TEST_DB_URL=postgresql+psycopg2cffi://postgres@/travis_ci_test
 
 [testenv:pypy-psycopg2cffi-local]

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,26 @@
 [tox]
-envlist = py27,py33,py34,pypy,docs,pep8
+envlist = py27{,-psycopg2cffi},py33,py34,py35{,-psycopg2cffi},pypy{,-psycopg2cffi},docs,pep8
 
 [testenv]
 deps =
+     py27-psycopg2cffi: psycopg2cffi
+     pypy-psycopg2cffi: psycopg2cffi
+     py35-psycopg2cffi: psycopg2cffi
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
 commands = py.test
+
+[testenv:pypy-psycopg2cffi]
+setenv = TEST_DB_URL=postgresql+psycopg2cffi://postgres@/travis_ci_test
+# Local Testing: `docker run -it --rm -p5432:5432 -ePOSTGRES_DB=travis_ci_test postgres`
+# Then uncomment the line below
+#setenv = TEST_DB_URL=postgresql+psycopg2cffi://postgres@127.0.01/travis_ci_test
+
+[testenv:py27-psycopg2cffi]
+setenv = TEST_DB_URL=postgresql+psycopg2cffi://postgres@/travis_ci_test
+
+[testenv:py35-psycopg2cffi]
+setenv = TEST_DB_URL=postgresql+psycopg2cffi://postgres@/travis_ci_test
 
 [testenv:docs]
 basepython = python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27{,-psycopg2cffi},py33,py34,py35{,-psycopg2cffi},pypy{,-psycopg2cffi},docs,pep8
+envlist = py27{,-psycopg2cffi},py33,py34{-psycopg2cffi},pypy{,-psycopg2cffi},docs,pep8
 
 [testenv]
 deps =
@@ -19,7 +19,7 @@ setenv = TEST_DB_URL=postgresql+psycopg2cffi://postgres@/travis_ci_test
 [testenv:py27-psycopg2cffi]
 setenv = TEST_DB_URL=postgresql+psycopg2cffi://postgres@/travis_ci_test
 
-[testenv:py35-psycopg2cffi]
+[testenv:py34-psycopg2cffi]
 setenv = TEST_DB_URL=postgresql+psycopg2cffi://postgres@/travis_ci_test
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,8 @@
 [tox]
-envlist = py27{,-psycopg2cffi},py33,py34{-psycopg2cffi},pypy{,-psycopg2cffi},docs,pep8
+envlist = py27,py33,py34,pypy,docs,pep8
 
 [testenv]
 deps =
-     py27-psycopg2cffi: psycopg2cffi
-     pypy-psycopg2cffi: psycopg2cffi
-     py35-psycopg2cffi: psycopg2cffi
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
 commands = py.test

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,18 @@ setenv = TEST_DB_URL=postgresql+psycopg2cffi://postgres@/travis_ci_test
 [testenv:py34-psycopg2cffi]
 setenv = TEST_DB_URL=postgresql+psycopg2cffi://postgres@/travis_ci_test
 
+[testenv:pypy-psycopg2cffi-local]
+# Local Testing: `docker run -it --rm -p5432:5432 -ePOSTGRES_DB=alchimia_tox postgres`
+setenv = TEST_DB_URL=postgresql+psycopg2cffi://postgres@127.0.0.1/alchimia_tox
+
+[testenv:py27-psycopg2cffi-local]
+# Local Testing: `docker run -it --rm -p5432:5432 -ePOSTGRES_DB=alchimia_tox postgres`
+setenv = TEST_DB_URL=postgresql+psycopg2cffi://postgres@127.0.0.1/alchimia_tox
+
+[testenv:py35-psycopg2cffi-local]
+# Local Testing: `docker run -it --rm -p5432:5432 -ePOSTGRES_DB=alchimia_tox postgres`
+setenv = TEST_DB_URL=postgresql+psycopg2cffi://postgres@127.0.0.1/alchimia_tox
+
 [testenv:docs]
 basepython = python2.7
 deps = sphinx


### PR DESCRIPTION
The same general method should work for exercising other backing DBs.

I also added a new test that exercises the pain I see with pypy & psycopg2cffi (Issue #32 and probably Issue #30). 

I tried to actually troubleshoot the issue, but it's too dense for me. This is the best I can do for contribution.