### PR TITLE
Fixes pypy resource leak by supporting TwistedResultProxy.close()

### DIFF
--- a/alchimia/engine.py
+++ b/alchimia/engine.py
@@ -162,6 +162,9 @@ class TwistedResultProxy(object):
     def keys(self):
         return self._deferrer(self._result_proxy.keys)
 
+    def close(self):
+        return self._result_proxy.close()
+
     @property
     def returns_rows(self):
         return self._result_proxy.returns_rows

--- a/alchimia/engine.py
+++ b/alchimia/engine.py
@@ -163,7 +163,7 @@ class TwistedResultProxy(object):
         return self._deferrer(self._result_proxy.keys)
 
     def close(self):
-        return self._result_proxy.close()
+        return self._deferrer(self._result_proxy.close)
 
     @property
     def returns_rows(self):

--- a/docs/api-reference.rst
+++ b/docs/api-reference.rst
@@ -113,6 +113,11 @@ you to :doc:`file bugs </contributing>` in those cases.
         Like the SQLAlchemy method of the same name, except returns a
         ``Deferred`` which fires with the scalar value.
 
+    .. method:: close()
+
+	Like the SQLAlchemy method of the same name, it releases the
+	resources used and releases the underlying DB connection.
+
     .. attribute:: returns_rows
 
         Like the SQLAlchemy attribute of the same name.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,6 +48,10 @@ Getting started
         for user in d_users:
             print "Username: %s" % user[users.c.name]
 
+	# Queries that return results should be explicitly closed to
+	# release the connection
+	result.close()
+
     if __name__ == "__main__":
         react(main, [])
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -253,3 +253,13 @@ class TestResultProxy(unittest.TestCase):
         d = engine.execute(tbl.insert().values())
         result = self.successResultOf(d)
         assert result.inserted_primary_key == [1]
+
+    def test_close(self):
+        engine = self.create_default_table()
+        d = engine.execute("INSERT INTO testtable VALUES (1)")
+        self.successResultOf(d)
+        d = engine.execute("INSERT INTO testtable VALUES (2)")
+        self.successResultOf(d)
+        d = engine.execute("SELECT * FROM testtable")
+        result = self.successResultOf(d)
+        self.successResultOf(result.close())


### PR DESCRIPTION
So, as it turns out. The SqlAlchemy docs say "Always close your ResultProxy, kids": http://docs.sqlalchemy.org/en/latest/core/connections.html#basic-usage

Apparently I'd missed this, somehow, since forever... but there you go. Now TwistedResultProxy proxies .close().