### PR TITLE
support for SAVEPOINT

### DIFF
--- a/alchimia/engine.py
+++ b/alchimia/engine.py
@@ -123,6 +123,12 @@ class TwistedConnection(object):
         return (self._defer_to_cxn(self._connection.begin, *args, **kwargs)
                 .addCallback(lambda txn: TwistedTransaction(txn, self)))
 
+    def begin_nested(self, *args, **kwargs):
+        return (
+            self._defer_to_cxn(self._connection.begin_nested, *args, **kwargs)
+            .addCallback(lambda txn: TwistedTransaction(txn, self))
+        )
+
     def in_transaction(self):
         return self._connection.in_transaction()
 

--- a/alchimia/engine.py
+++ b/alchimia/engine.py
@@ -41,7 +41,9 @@ def _defer_to_worker(deliver, worker, work, *args, **kwargs):
 
 class TwistedEngine(object):
     def __init__(self, pool, dialect, url, reactor=None,
-                 create_worker=_threaded_worker, **kwargs):
+                 create_worker=_threaded_worker,
+                 customize_sub_engine=None,
+                 **kwargs):
         if reactor is None:
             raise TypeError("Must provide a reactor")
 
@@ -49,6 +51,8 @@ class TwistedEngine(object):
         self._reactor = reactor
         self._create_worker = create_worker
         self._engine_worker = self._create_worker()
+        if customize_sub_engine is not None:
+            customize_sub_engine(self._engine)
 
     def _defer_to_engine(self, f, *a, **k):
         return _defer_to_worker(self._reactor.callFromThread,

--- a/alchimia/engine.py
+++ b/alchimia/engine.py
@@ -42,7 +42,7 @@ def _defer_to_worker(deliver, worker, work, *args, **kwargs):
 class TwistedEngine(object):
     def __init__(self, pool, dialect, url, reactor=None,
                  create_worker=_threaded_worker,
-                 customize_sub_engine=None,
+                 _customize_sub_engine=None,
                  **kwargs):
         if reactor is None:
             raise TypeError("Must provide a reactor")
@@ -51,8 +51,8 @@ class TwistedEngine(object):
         self._reactor = reactor
         self._create_worker = create_worker
         self._engine_worker = self._create_worker()
-        if customize_sub_engine is not None:
-            customize_sub_engine(self._engine)
+        if _customize_sub_engine is not None:
+            _customize_sub_engine(self._engine)
 
     def _defer_to_engine(self, f, *a, **k):
         return _defer_to_worker(self._reactor.callFromThread,

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -40,7 +40,7 @@ def create_engine(**kwargs):
                 # emit our own BEGIN
                 conn.execute("BEGIN")
 
-        kwargs['customize_sub_engine'] = actually_transactional_sqlite
+        kwargs['_customize_sub_engine'] = actually_transactional_sqlite
 
     engine = sqlalchemy.create_engine(
         TEST_DB_URL, strategy=TWISTED_STRATEGY,
@@ -180,6 +180,13 @@ class TestConnection(unittest.TestCase):
         save = self.successResultOf(conn.begin_nested())
         self.successResultOf(conn.execute("insert into effects values (2)"))
         self.successResultOf(save.rollback())
+        self.assertEqual(
+            [(1,)],
+            self.successResultOf(
+                self.successResultOf(conn.execute("select * from effects"))
+                .fetchall()
+            )
+        )
         self.successResultOf(txn.commit())
 
     def test_transaction_commit(self):


### PR DESCRIPTION
The previous "test_nested_transaction" wasn't actually testing nested transactions, it was testing calling `.begin()` repeatedly.