### PR TITLE
pep8 tooling now forbids 'except:', so tell it we're serious

### DIFF
--- a/alchimia/engine.py
+++ b/alchimia/engine.py
@@ -31,7 +31,7 @@ def _defer_to_worker(deliver, worker, work, *args, **kwargs):
     def container():
         try:
             result = work(*args, **kwargs)
-        except:
+        except BaseException:
             f = Failure()
             deliver(lambda: deferred.errback(f))
         else:


### PR DESCRIPTION
CI is currently failing on empty new branches, so let's make it not do that.