### PR TITLE
add a new wrap_engine entry-point to avoid abusing sqlalchemy strategies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Getting started
         d_users = yield result.fetchall()
         # Print out the users
         for user in d_users:
-            print "Username: %s" % user[users.c.name]
+            print("Username: %s" % user[users.c.name])
 
     if __name__ == "__main__":
         react(main, [])

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Getting started
 
 .. code:: python
 
-    from alchimia import TWISTED_STRATEGY
+    from alchimia import wrap_engine
 
     from sqlalchemy import (
         create_engine, MetaData, Table, Column, Integer, String
@@ -22,9 +22,7 @@ Getting started
 
     @inlineCallbacks
     def main(reactor):
-        engine = create_engine(
-            "sqlite://", reactor=reactor, strategy=TWISTED_STRATEGY
-        )
+        engine = wrap_engine(reactor, create_engine("sqlite://"))
 
         metadata = MetaData()
         users = Table("users", metadata,

--- a/alchimia/__init__.py
+++ b/alchimia/__init__.py
@@ -1,10 +1,12 @@
 from __future__ import absolute_import, division
 
-from alchimia.strategy import TwistedEngineStrategy, TWISTED_STRATEGY
+from alchimia.strategy import TWISTED_STRATEGY
+from alchimia.engine import TwistedEngine
 
+wrap_engine = TwistedEngine.from_sqlalchemy_engine
+del TwistedEngine
 
 __all__ = [
     "TWISTED_STRATEGY",
+    "wrap_engine",
 ]
-
-TwistedEngineStrategy()

--- a/alchimia/engine.py
+++ b/alchimia/engine.py
@@ -42,7 +42,7 @@ def _defer_to_worker(deliver, worker, work, *args, **kwargs):
 class TwistedEngine(object):
     def __init__(self, pool, dialect, url, reactor=None,
                  create_worker=_threaded_worker,
-                 _customize_sub_engine=None,
+                 customize_sub_engine=None,
                  **kwargs):
         if reactor is None:
             raise TypeError("Must provide a reactor")
@@ -51,8 +51,8 @@ class TwistedEngine(object):
         self._reactor = reactor
         self._create_worker = create_worker
         self._engine_worker = self._create_worker()
-        if _customize_sub_engine is not None:
-            _customize_sub_engine(self._engine)
+        if customize_sub_engine is not None:
+            customize_sub_engine(self._engine)
 
     def _defer_to_engine(self, f, *a, **k):
         return _defer_to_worker(self._reactor.callFromThread,

--- a/alchimia/engine.py
+++ b/alchimia/engine.py
@@ -42,7 +42,6 @@ def _defer_to_worker(deliver, worker, work, *args, **kwargs):
 class TwistedEngine(object):
     def __init__(self, pool, dialect, url, reactor=None,
                  create_worker=_threaded_worker,
-                 customize_sub_engine=None,
                  **kwargs):
         if reactor is None:
             raise TypeError("Must provide a reactor")
@@ -51,8 +50,18 @@ class TwistedEngine(object):
         self._reactor = reactor
         self._create_worker = create_worker
         self._engine_worker = self._create_worker()
-        if customize_sub_engine is not None:
-            customize_sub_engine(self._engine)
+
+    @classmethod
+    def from_sqlalchemy_engine(cls, reactor, engine,
+                               create_worker=_threaded_worker):
+        # Leaving the existing __init__ in place for compatibility reasons,
+        # this is a completely alternate constructor.
+        self = cls.__new__(cls)
+        self._reactor = reactor
+        self._engine = engine
+        self._create_worker = create_worker
+        self._engine_worker = create_worker()
+        return self
 
     def _defer_to_engine(self, f, *a, **k):
         return _defer_to_worker(self._reactor.callFromThread,

--- a/alchimia/strategy.py
+++ b/alchimia/strategy.py
@@ -18,4 +18,5 @@ class TwistedEngineStrategy(DefaultEngineStrategy):
     name = TWISTED_STRATEGY
     engine_cls = TwistedEngine
 
+
 TwistedEngineStrategy()

--- a/alchimia/strategy.py
+++ b/alchimia/strategy.py
@@ -17,3 +17,5 @@ class TwistedEngineStrategy(DefaultEngineStrategy):
 
     name = TWISTED_STRATEGY
     engine_cls = TwistedEngine
+
+TwistedEngineStrategy()

--- a/docs/api-reference.rst
+++ b/docs/api-reference.rst
@@ -12,6 +12,45 @@ you to :doc:`file bugs </contributing>` in those cases.
     Mostly like :class:`sqlalchemy.engine.Engine` except some of the methods
     return ``Deferreds``.
 
+    .. method:: __init__(pool, dialect, url, reactor=None,
+                create_worker=threaded_worker, customize_sub_engine=None)
+
+       ``TwistedEngine`` is normally created via ``create_engine(...,
+       reactor=reactor, strategy=TWISTED_STRATEGY)`` rather than called
+       directly.  However, ``create_engine`` relays its keyword arguments, so
+       three of the keyword arguments here may be of interest to applications:
+
+       - ``reactor`` - the Twisted reactor to use with this ``TwistedEngine``.
+         This should always be explicitly passed to ``create_engine``.
+
+       - ``create_worker`` - a callable that will return an object with 2
+         methods, ``do(work)`` (expected to call the 0-argument ``work``
+         callable in a thread), and ``quit()``, expected to stop any future
+         work from occurring.  It may be useful to stub out the default
+         threaded implementation for testing purposes.
+
+       - ``customize_sub_engine`` - A callable that will take the *underlying*
+         SQLAlchemy engine when it is created, in order to allow application
+         code to customize it.  This is intended to enable event-hook access,
+         particularly to facilitate debugging and driver-specific configuration
+         or workarounds `like this
+         <http://docs.sqlalchemy.org/en/latest/dialects/sqlite.html#serializable-isolation-savepoints-transactional-ddl>`_.
+         However, please be aware that this has some implementation
+         limitations:
+
+         1. Any callable passed as ``customize_sub_engine`` will be run in a
+            threadpool thread, not the main thread, as it is run where the
+            Engine is created.  This means it's safe to use APIs on the engine,
+            but it is *not* safe to call Twisted or reactor APIs in either this
+            callable or in any event-listeners registered on the underlying
+            engine itself, which will also be run in the database threadpool
+            appropriate to the connection that the event is occurring on.
+
+         2. While currently all Alchimia drivers are simply threaded wrappers
+            around existing synchronous SQLAlchemy drivers, this argument may
+            become a no-op or an error with any future natively-asynchronous
+            drivers.
+
     .. method:: connect()
 
         Like the SQLAlchemy method of the same name, except returns a

--- a/docs/api-reference.rst
+++ b/docs/api-reference.rst
@@ -12,8 +12,8 @@ you to :doc:`file bugs </contributing>` in those cases.
     Mostly like :class:`sqlalchemy.engine.Engine` except some of the methods
     return ``Deferreds``.
 
-    .. method:: __init__(pool, dialect, url, reactor=None,
-                create_worker=threaded_worker, customize_sub_engine=None)
+    .. method:: __init__(pool, dialect, url, reactor=..., create_worker=...,
+                         customize_sub_engine=...)
 
        ``TwistedEngine`` is normally created via ``create_engine(...,
        reactor=reactor, strategy=TWISTED_STRATEGY)`` rather than called

--- a/docs/api-reference.rst
+++ b/docs/api-reference.rst
@@ -12,8 +12,7 @@ you to :doc:`file bugs </contributing>` in those cases.
     Mostly like :class:`sqlalchemy.engine.Engine` except some of the methods
     return ``Deferreds``.
 
-    .. method:: __init__(pool, dialect, url, reactor=..., create_worker=...,
-                         customize_sub_engine=...)
+    .. method:: __init__(pool, dialect, url, reactor=..., create_worker=..., customize_sub_engine=...)
 
        ``TwistedEngine`` is normally created via ``create_engine(...,
        reactor=reactor, strategy=TWISTED_STRATEGY)`` rather than called

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -31,6 +31,7 @@ def create_engine(**kwargs):
         # necessary to test savepoints in SQLite.
 
         sub_engine = sqlalchemy.create_engine(TEST_DB_URL, **kwargs)
+
         @listens_for(sub_engine, "connect")
         def do_connect(dbapi_connection, connection_record):
             # disable pysqlite's emitting of the BEGIN statement entirely.

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -40,7 +40,7 @@ def create_engine(**kwargs):
                 # emit our own BEGIN
                 conn.execute("BEGIN")
 
-        kwargs['_customize_sub_engine'] = actually_transactional_sqlite
+        kwargs.update(customize_sub_engine=actually_transactional_sqlite)
 
     engine = sqlalchemy.create_engine(
         TEST_DB_URL, strategy=TWISTED_STRATEGY,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,pypy,docs,pep8
+envlist = py27,py34,py35,pypy,docs,pep8
 
 [testenv]
 deps =


### PR DESCRIPTION
If we needed it for the tests, other applications will indubitably need it in real life.