### PR TITLE
twisted has dropped python 3.4, and so shall we

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ matrix:
       env: TOX_ENV=py27
     - python: 2.7
       env: TOX_ENV=py27-psycopg2cffi
-    - python: 3.4
-      env: TOX_ENV=py34
     - python: 3.5
       env: TOX_ENV=py35
     - python: 3.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,pypy,docs,pep8
+envlist = py27,py35,pypy,docs,pep8
 
 [testenv]
 deps =


### PR DESCRIPTION
Fixes #46 .